### PR TITLE
redundant usage of Blocking

### DIFF
--- a/examples/src/main/scala/circular.example.scala
+++ b/examples/src/main/scala/circular.example.scala
@@ -4,7 +4,6 @@ package circular
 import kvs.seq._, kvs.store.Rng.{Conf=>RngConf}
 import proto._, macrosapi._
 import zio._, zio.console._
-import zio.blocking.Blocking
 import zio.clock.Clock
 
 object App {
@@ -15,7 +14,7 @@ object App {
     val actorSystem = akkaConf >>> ActorSystem.live.orDie
     val dbaConf     = Dba.rngConf(RngConf(dir="../data/example-circular"))
     val dba         = actorSystem ++ dbaConf ++ ZLayer.requires[Clock] >>> Dba.live
-    val kvs         = actorSystem ++ dba ++ ZLayer.requires[Clock with Blocking] >+> Kvs.live
+    val kvs         = actorSystem ++ dba ++ ZLayer.requires[Clock] >+> Kvs.live
 
     val app =
       for {

--- a/examples/src/main/scala/ring.example.scala
+++ b/examples/src/main/scala/ring.example.scala
@@ -4,7 +4,6 @@ package ring
 import kvs.seq._, kvs.store.Rng.{Conf=>RngConf}
 import proto._, macrosapi._
 import zio._, zio.console._
-import zio.blocking.Blocking
 import zio.clock.Clock
 
 object App {
@@ -15,7 +14,7 @@ object App {
     val actorSystem = akkaConf >>> ActorSystem.live.orDie
     val dbaConf     = Dba.rngConf(RngConf(dir="../data/example-feed"))
     val dba         = actorSystem ++ dbaConf ++ ZLayer.requires[Clock] >>> Dba.live
-    val kvs         = actorSystem ++ dba ++ ZLayer.requires[Clock with Blocking] >+> Kvs.live
+    val kvs         = actorSystem ++ dba ++ ZLayer.requires[Clock] >+> Kvs.live
 
     val app =
       for {

--- a/src/main/scala/circular.scala
+++ b/src/main/scala/circular.scala
@@ -3,8 +3,7 @@ package kvs
 import zero.ext._, option._
 import proto._, macrosapi._
 import zio.{ZIO, IO} 
-import zio.blocking.Blocking
-import zio.stream.ZStream
+import zio.stream._
 
 import store.Dba
 
@@ -21,12 +20,12 @@ object circular {
 
   object meta {
     def del(id: FdKey        )(implicit dba: Dba): IO[Err, Unit] = dba.del(id)
-    def put(id: FdKey, el: Fd)(implicit dba: Dba): ZIO[Blocking, Err, Unit] =
+    def put(id: FdKey, el: Fd)(implicit dba: Dba): IO[Err, Unit] =
       for {
         p <- pickle(el)
         x <- dba.put(id, p)
       } yield x
-    def get(id: FdKey        )(implicit dba: Dba): ZIO[Blocking, Err, Option[Fd]] =
+    def get(id: FdKey        )(implicit dba: Dba): IO[Err, Option[Fd]] =
       dba.get(id).flatMap{
         case Some(x) => unpickle[Fd](x).map(_.some)
         case None    => IO.succeed(none)
@@ -37,7 +36,7 @@ object circular {
     EnKey(fid, ElKey(encodeToBytes(Idx(idx))))
   }
 
-  def put(fid: FdKey, idx: Long, data: Bytes)(implicit dba: Dba): ZIO[Blocking, Err, Unit] = {
+  def put(fid: FdKey, idx: Long, data: Bytes)(implicit dba: Dba): IO[Err, Unit] = {
     for {
       fd <- meta.get(fid)
       sz  = Math.max(2L, fd.cata(_.size, idx))
@@ -47,7 +46,7 @@ object circular {
     } yield ()
   }
 
-  def add(fid: FdKey, size1: Long, data: Bytes)(implicit dba: Dba): ZIO[Blocking, Err, Unit] = {
+  def add(fid: FdKey, size1: Long, data: Bytes)(implicit dba: Dba): IO[Err, Unit] = {
     for {
       m    <- meta.get(fid)
       size  = Math.max(2L, size1)
@@ -58,14 +57,14 @@ object circular {
     } yield ()
   }
 
-  def get(fid: FdKey)(idx: Long)(implicit dba: Dba): ZIO[Blocking, Err, Option[Bytes]] = {
+  def get(fid: FdKey)(idx: Long)(implicit dba: Dba): IO[Err, Option[Bytes]] = {
     for {
       x <- dba.get(key(fid, idx))
       y <- x.cata(unpickle[En](_).map(_.data.some), IO.succeed(none))
     } yield y
   }
 
-  def all(fid: FdKey)(implicit dba: Dba): ZStream[Blocking, Err, Bytes] = {
+  def all(fid: FdKey)(implicit dba: Dba): Stream[Err, Bytes] = {
     val res = for {
       m  <- meta.get(fid)
     } yield m.cata(m =>

--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -1,7 +1,6 @@
 import java.util.Arrays
 import proto._
-import zio.{ZIO, URIO, IO}
-import zio.blocking.Blocking
+import zio._
 
 package object kvs {
   type Res[A] = Either[Err, A]
@@ -30,9 +29,9 @@ package object kvs {
   object ElKeyExt {
     val MinValue = ElKey(Bytes.unsafeWrap(Array(Byte.MinValue)))
     val EmptyValue = ElKey(Bytes.empty)
-    def from_str(x: String): URIO[Blocking, ElKey] = IO.effect(ElKey(Bytes.unsafeWrap(x.getBytes("utf8")))).orDie
+    def from_str(x: String): UIO[ElKey] = IO.effectTotal(ElKey(Bytes.unsafeWrap(x.getBytes("utf8"))))
   }
 
-  def pickle  [A](e: A)    (implicit c: MessageCodec[A]): URIO[Blocking, Bytes] = IO.effectTotal(encodeToBytes[A](e))
-  def unpickle[A](a: Bytes)(implicit c: MessageCodec[A]): URIO[Blocking, A]     = IO.effect(decode[A](a)).orDie // is defect
+  def pickle  [A](e: A)    (implicit c: MessageCodec[A]): UIO[Bytes] = IO.effectTotal(encodeToBytes[A](e))
+  def unpickle[A](a: Bytes)(implicit c: MessageCodec[A]): UIO[A]     = IO.effect(decode[A](a)).orDie // is defect
 }

--- a/src/main/scala/search/dir.scala
+++ b/src/main/scala/search/dir.scala
@@ -55,7 +55,7 @@ class KvsDirectory(dir: FdKey)(implicit dba: Dba) extends BaseDirectory(new KvsL
   override def listAll(): Array[String] = {
     ensureOpen()
     val z = enh.all(dir).map(_._1.bytes.mkString).runCollect.map(_.sorted.toArray)
-    runtime.unsafeRunSync(z.provideLayer(ZEnv.live)).getOrElse(e => throw new IOException(FiberFailure(e)))
+    runtime.unsafeRunSync(z).getOrElse(e => throw new IOException(FiberFailure(e)))
   }
 
   /**
@@ -76,7 +76,7 @@ class KvsDirectory(dir: FdKey)(implicit dba: Dba) extends BaseDirectory(new KvsL
       x     <- enh.remove(EnKey(dir, name1))
       _     <- x.fold(enh.cleanup(dir), IO.fail(FileNotExists(path)))
     } yield ()
-    runtime.unsafeRunSync(z.provideLayer(ZEnv.live)).getOrElse(c => throw c.failureOption.collect{
+    runtime.unsafeRunSync(z).getOrElse(c => throw c.failureOption.collect{
       case _: FileNotExists => new NoSuchFileException(s"${dir}/${name}")
     }.getOrElse(new IOException(FiberFailure(c))))
   }
@@ -97,7 +97,7 @@ class KvsDirectory(dir: FdKey)(implicit dba: Dba) extends BaseDirectory(new KvsL
       name1 <- ElKeyExt.from_str(name)
       l     <- flh.size(PathKey(dir, name1))
     } yield l
-    runtime.unsafeRunSync(z.provideLayer(ZEnv.live)).getOrElse(c => throw c.failureOption.collect{
+    runtime.unsafeRunSync(z).getOrElse(c => throw c.failureOption.collect{
       case _: FileNotExists => new NoSuchFileException(s"${dir}/${name}")
     }.getOrElse(new IOException(FiberFailure(c))))
   }
@@ -122,7 +122,7 @@ class KvsDirectory(dir: FdKey)(implicit dba: Dba) extends BaseDirectory(new KvsL
       _     <- IO.effectTotal(outs += ((name, out)))
       io    <- IO.effectTotal(new OutputStreamIndexOutput(s"${dir}/${name}", name, out, 8192))
     } yield io
-    runtime.unsafeRunSync(z.provideLayer(ZEnv.live)).getOrElse(c => throw c.failureOption.collect{
+    runtime.unsafeRunSync(z).getOrElse(c => throw c.failureOption.collect{
       case _: EntryExists       => new FileAlreadyExistsException(s"${dir}/${name}")
       case _: FileAlreadyExists => new FileAlreadyExistsException(s"${dir}/${name}")
     }.getOrElse(new IOException(FiberFailure(c))))
@@ -151,7 +151,7 @@ class KvsDirectory(dir: FdKey)(implicit dba: Dba) extends BaseDirectory(new KvsL
       case _: FileAlreadyExists => true
       case _ => false
     }
-    runtime.unsafeRunSync(z.provideLayer(ZEnv.live)).getOrElse(c => throw new IOException(FiberFailure(c)))
+    runtime.unsafeRunSync(z).getOrElse(c => throw new IOException(FiberFailure(c)))
   }
 
   /**
@@ -177,7 +177,7 @@ class KvsDirectory(dir: FdKey)(implicit dba: Dba) extends BaseDirectory(new KvsL
                 )
       } yield ()
     }.runDrain
-    runtime.unsafeRunSync(z.provideLayer(ZEnv.live)).getOrElse(c => throw new IOException(FiberFailure(c)))
+    runtime.unsafeRunSync(z).getOrElse(c => throw new IOException(FiberFailure(c)))
   }
 
   override def syncMetaData(): Unit = {
@@ -210,7 +210,7 @@ class KvsDirectory(dir: FdKey)(implicit dba: Dba) extends BaseDirectory(new KvsL
       _       <- enh.remove(EnKey(dir, source1))
       _       <- enh.cleanup(dir)
     } yield ()
-    runtime.unsafeRunSync(z.provideLayer(ZEnv.live)).getOrElse(c => throw new IOException(FiberFailure(c)))
+    runtime.unsafeRunSync(z).getOrElse(c => throw new IOException(FiberFailure(c)))
   }
 
   /**
@@ -228,7 +228,7 @@ class KvsDirectory(dir: FdKey)(implicit dba: Dba) extends BaseDirectory(new KvsL
       name1 <- ElKeyExt.from_str(name)
       bs    <- flh.stream(PathKey(dir, name1)).runCollect
     } yield new BytesIndexInput(s"${dir}/${name}", bs.toVector)
-    runtime.unsafeRunSync(z.provideLayer(ZEnv.live)).getOrElse(c => throw c.failureOption.collect{
+    runtime.unsafeRunSync(z).getOrElse(c => throw c.failureOption.collect{
       case FileNotExists(path) => new NoSuchFileException(s"${path.dir}/${path.name}")
     }.getOrElse(new IOException(FiberFailure(c))))
   }

--- a/src/main/scala/seq/Kvs.scala
+++ b/src/main/scala/seq/Kvs.scala
@@ -1,7 +1,6 @@
 package kvs.seq
 
 import zio.RLayer
-import zio.blocking.Blocking
 import zio.clock.Clock
 
 object Kvs {
@@ -10,6 +9,6 @@ object Kvs {
   val file    : KvsFile    .type = KvsFile
   val search  : KvsSearch  .type = KvsSearch
 
-  val live: RLayer[ActorSystem with Dba with Clock with Blocking, Kvs] =
+  val live: RLayer[ActorSystem with Dba with Clock, Kvs] =
     KvsFeed.live ++ KvsCircular.live ++ KvsFile.live ++ KvsSearch.live
 }

--- a/src/main/scala/seq/package.scala
+++ b/src/main/scala/seq/package.scala
@@ -21,9 +21,6 @@ package object seq {
   type AkkaConf    = Has[ActorSystem.Conf]
   type ActorSystem = Has[ActorSystem.Service]
 
-  // type     IO[Err, A] =     ZIO[ZEnv, Err, A]
-  // type Stream[Err, A] = ZStream[ZEnv, Err, A]
-
   object Dba {
     type Service = RootDba
 

--- a/src/main/scala/store/rks.scala
+++ b/src/main/scala/store/rks.scala
@@ -5,7 +5,6 @@ import zero.ext._, option._
 import proto._, macrosapi._
 import org.rocksdb.{util=>_,_}
 import zio.{ZIO, IO, Schedule, Has}
-import zio.blocking.Blocking
 import zio.clock.Clock
 import zio.duration._
 

--- a/src/main/scala/store/rng.scala
+++ b/src/main/scala/store/rng.scala
@@ -9,7 +9,6 @@ import proto._, macrosapi._
 import rng.store.{ReadonlyStore, WriteStore}, rng.Hashing
 import zero.ext._, either._
 import zio._
-import zio.blocking.Blocking
 import zio.clock.Clock
 
 object Rng {


### PR DESCRIPTION
### Blocking Synchronous Side-Effects

Some side-effects use blocking IO or otherwise put a thread into a waiting state. If not carefully managed, these side-effects can deplete threads from your application's main thread pool, resulting in work starvation.

ZIO provides the zio.blocking package, which can be used to safely convert such blocking side-effects into ZIO effects.